### PR TITLE
Add 'zoom' option for video saving

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -67,6 +67,7 @@ do
          {arg='path', type='string', help='path to video'},
          {arg='width', type='number', help='width', default=320},
          {arg='height', type='number', help='height', default=240},
+         {arg='zoom', type='number', help='zoom factor', default=1},
          {arg='fps', type='number', help='frames per second', default=10},
          {arg='length', type='number', help='length, in seconds', default=10},
          {arg='seek', type='number', help='seek to pos. in seconds', default=0},
@@ -381,10 +382,10 @@ do
          ffmpeg_cmd = (ffmpeg_cmd ..
                        ' -i ' .. sys.concat(self[c].path, format))
       end
-      ffmpeg_cmd = ffmpeg_cmd .. ' -vcodec mjpeg -qscale 1 -an ' .. outpath .. '.avi'
+      ffmpeg_cmd = ffmpeg_cmd .. ' -sws_flags neighbor -vf scale=' .. self.zoom .. '*iw:' .. self.zoom .. '*ih -vcodec mjpeg -qscale 1 -an ' .. outpath .. '.avi'
       for c = 2,nchannels do
          ffmpeg_cmd = (ffmpeg_cmd ..
-                       '  -vcodec mjpeg -qscale 1 -an  -newvideo')
+                       ' -sws_flags neighbor -vf scale=' .. self.zoom .. '*iw:' .. self.zoom .. '*ih -vcodec mjpeg -qscale 1 -an  -newvideo')
       end
       ffmpeg_cmd = ffmpeg_cmd .. ' 2> /dev/null'
 


### PR DESCRIPTION
Hello Clement
This pull request adds an option 'zoom' to enlarge the videos when saving them. This is to prevent some viewers (such as Mac OS X's default viewer) to be in charge of rescaling, which they often do with bilinear algorithms tha add some blur unsuitable to Machine Learning applications.
Please let me know if there's anything you want me to change in there!
Cheers and thanks for the great work
